### PR TITLE
chore: bring back sample-docs/

### DIFF
--- a/{{ cookiecutter.repo_name }}/sample-docs/README.md
+++ b/{{ cookiecutter.repo_name }}/sample-docs/README.md
@@ -4,4 +4,4 @@ Preprocessing pipeline API repositories may include sample documents (inputs) th
 
 Naturally, adding a few small files directly in this directory with a `git add` is fine. However, if the sample docs are larger files (or they are many smaller ones), it is recommended to provide a `make` target instead to download the files. E.g. [make dl-test-artifacts](https://github.com/Unstructured-IO/pipeline-sec-filings/blob/083b56f/Makefile#L136) in [pipeline-sec-filings](https://github.com/Unstructured-IO/pipeline-sec-filings/).
 
-If your pipeline does not have sample-docs, go ahead and delete this README.md (and folder) :)
+If your pipeline is not going to have sample-docs, go ahead and delete this README.md (and folder) :)

--- a/{{ cookiecutter.repo_name }}/sample-docs/README.md
+++ b/{{ cookiecutter.repo_name }}/sample-docs/README.md
@@ -1,0 +1,7 @@
+# The sample-docs/ convention
+
+Preprocessing pipeline API repositories may include sample documents (inputs) that could be posted to its API(s). By convention, this is the directory to place them in.
+
+Naturally, adding a few small files directly in this directory with a `git add` is fine. However, if the sample docs are larger files (or they are many smaller ones), it is recommended to provide a `make` target instead to download the files. E.g. [make dl-test-artifacts](https://github.com/Unstructured-IO/pipeline-sec-filings/blob/083b56f/Makefile#L136) in [pipeline-sec-filings](https://github.com/Unstructured-IO/pipeline-sec-filings/).
+
+If your pipeline does not have sample-docs, go ahead and delete this README.md (and folder) :)

--- a/{{ cookiecutter.repo_name }}/sample-docs/README.md
+++ b/{{ cookiecutter.repo_name }}/sample-docs/README.md
@@ -2,6 +2,6 @@
 
 Preprocessing pipeline API repositories may include sample documents (inputs) that could be posted to its API(s). By convention, this is the directory to place them in.
 
-Naturally, adding a few small files directly in this directory with a `git add` is fine. However, if the sample docs are larger files (or they are many smaller ones), it is recommended to provide a `make` target instead to download the files. E.g. [make dl-test-artifacts](https://github.com/Unstructured-IO/pipeline-sec-filings/blob/083b56f/Makefile#L136) in [pipeline-sec-filings](https://github.com/Unstructured-IO/pipeline-sec-filings/).
+Naturally, adding a few small files directly in this directory with `git add` is fine. However, if the sample docs are larger files (or they are many smaller ones), it is recommended to provide a `make` target instead to download the files. E.g. [make dl-test-artifacts](https://github.com/Unstructured-IO/pipeline-sec-filings/blob/083b56f/Makefile#L136) in [pipeline-sec-filings](https://github.com/Unstructured-IO/pipeline-sec-filings/).
 
 If your pipeline is not going to have sample-docs, go ahead and delete this README.md (and folder) :)


### PR DESCRIPTION
Bring back the sample-docs dir that was just removed :)

Though, per discussion with @qued , adds a README.md to be explicit about the purpose of the `sample-docs/` dir and why it is initially empty.