### PR TITLE
feat: more robust notebook check script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-tmp*
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -38,6 +36,9 @@ MANIFEST
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+
+# Pycharm
+.idea/
 
 # Unit test / coverage reports
 htmlcov/
@@ -78,6 +79,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+nbs/
 
 # IPython
 profile_default/
@@ -130,5 +132,58 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Test project
-pipeline-testproject
+# ingest outputs
+/structured-output
+
+# suggested ingest mirror directory
+/mirror
+
+## https://github.com/github/gitignore/blob/main/Global/Emacs.gitignore (partial)
+
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+## https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+## https://github.com/github/gitignore/blob/main/Global/Vim.gitignore
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+.DS_Store
+
+# Ruff cache
+.ruff_cache/

--- a/scripts/docker-validate.sh
+++ b/scripts/docker-validate.sh
@@ -35,7 +35,7 @@ if [[ $(curl -X 'POST' \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -F 'files=@Makefile' \
-     -F 'some_parameter=something' | grep 'Makefile:application/octet-stream') == "" ]]; then
+     -F 'some_parameter=something' | grep -P '(Makefile:application/octet-stream|Makefile:None)') == "" ]]; then
     echo "Did not get expected output from API"
     kill %1
     exit 1

--- a/{{ cookiecutter.repo_name }}/pipeline-notebooks/pipeline-process-file.ipynb
+++ b/{{ cookiecutter.repo_name }}/pipeline-notebooks/pipeline-process-file.ipynb
@@ -40,7 +40,7 @@
     "    file_content_type=None,\n",
     "    m_some_parameters=[],\n",
     "):\n",
-    "    return f\"{':'.join([filename, file_content_type, str(len(file.read()))])}\""
+    "    return f\"{':'.join([filename, str(file_content_type), str(len(file.read()))])}\""
    ]
   }
  ],

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
@@ -14,6 +14,7 @@ app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
+    docs_url="/{{ cookiecutter.pipeline_family }}/docs
 )
 
 app.include_router(process_file_router)

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
@@ -15,6 +15,7 @@ app = FastAPI(
     description="""""",
     version="1.0.0",
     docs_url="/{{ cookiecutter.pipeline_family }}/docs",
+    openapi_url="/{{ cookiecutter.pipeline_family }}/openapi.json",    
 )
 
 app.include_router(process_file_router)

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
@@ -14,7 +14,7 @@ app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
-    docs_url="/{{ cookiecutter.pipeline_family }}/docs"
+    docs_url="/{{ cookiecutter.pipeline_family }}/docs",
 )
 
 app.include_router(process_file_router)

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
@@ -6,27 +6,20 @@
 
 from fastapi import FastAPI, Request, status
 
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
-
 from .process_file import router as process_file_router
 from .process_text import router as process_text_router
 
 
-limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
 )
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.include_router(process_file_router)
 app.include_router(process_text_router)
 
 
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
+@app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)
+def healthcheck(request: Request):
     return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
@@ -14,7 +14,7 @@ app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
-    docs_url="/{{ cookiecutter.pipeline_family }}/docs
+    docs_url="/{{ cookiecutter.pipeline_family }}/docs"
 )
 
 app.include_router(process_file_router)

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
@@ -39,7 +39,7 @@ def pipeline_api(
     file_content_type=None,
     m_some_parameters=[],
 ):
-    return f"{':'.join([filename, file_content_type, str(len(file.read()))])}"
+    return f"{':'.join([filename, str(file_content_type), str(len(file.read()))])}"
 
 
 def get_validated_mimetype(file):

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
@@ -3,28 +3,33 @@
 # DO NOT MODIFY DIRECTLY
 #####################################################################
 
+import io
 import os
+import gzip
+import mimetypes
 from typing import List, Union
-from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter
-from slowapi.errors import RateLimitExceeded
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
+from fastapi import (
+    status,
+    FastAPI,
+    File,
+    Form,
+    Request,
+    UploadFile,
+    APIRouter,
+    HTTPException,
+)
 from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
+from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
 from typing import Optional, Mapping, Iterator, Tuple
 import secrets
 
 
-limiter = Limiter(key_func=get_remote_address)
 app = FastAPI()
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 router = APIRouter()
-
-RATE_LIMIT = os.environ.get("PIPELINE_API_RATE_LIMIT", "1/second")
 
 
 # pipeline-api
@@ -35,6 +40,36 @@ def pipeline_api(
     m_some_parameters=[],
 ):
     return f"{':'.join([filename, file_content_type, str(len(file.read()))])}"
+
+
+def get_validated_mimetype(file):
+    """
+    Return a file's mimetype, either via the file.content_type or the mimetypes lib if that's too
+    generic. If the user has set UNSTRUCTURED_ALLOWED_MIMETYPES, validate against this list and
+    return HTTP 400 for an invalid type.
+    """
+    content_type = file.content_type
+    if not content_type or content_type == "application/octet-stream":
+        content_type = mimetypes.guess_type(str(file.filename))[0]
+
+        # Markdown mimetype is too new for the library - just hardcode that one in for now
+        if not content_type and ".md" in file.filename:
+            content_type = "text/markdown"
+
+    allowed_mimetypes_str = os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES")
+    if allowed_mimetypes_str is not None:
+        allowed_mimetypes = allowed_mimetypes_str.split(",")
+
+        if content_type not in allowed_mimetypes:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
+            )
+
+    return content_type
 
 
 class MultipartMixedResponse(StreamingResponse):
@@ -95,13 +130,29 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
-@router.post("/{{ cookiecutter.pipeline_family }}/v0.0.1/process-file")
-@limiter.limit(RATE_LIMIT)
-async def pipeline_1(
+def ungz_file(file: UploadFile) -> UploadFile:
+    filename = str(file.filename) if file.filename else ""
+    gzip_file = gzip.open(file.file)
+    return UploadFile(
+        file=io.BytesIO(gzip_file.read()),
+        size=len(gzip_file.read()),
+        filename=filename[:-3] if len(filename) > 3 else "",
+        headers=Headers({"content-type": str(mimetypes.guess_type(filename)[0])}),
+    )
+
+
+@router.post("/{ cookiecutter.pipeline_family }}/v0/process-file")
+@router.post("/{ cookiecutter.pipeline_family }}/v0.0.1/process-file")
+def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),
     some_parameters: List[str] = Form(default=[]),
 ):
+    if files:
+        for file_index in range(len(files)):
+            if files[file_index].content_type == "application/gzip":
+                files[file_index] = ungz_file(files[file_index])
+
     content_type = request.headers.get("Accept")
 
     if isinstance(files, list) and len(files):
@@ -121,13 +172,15 @@ async def pipeline_1(
 
             def response_generator(is_multipart):
                 for file in files:
+                    file_content_type = get_validated_mimetype(file)
+
                     _file = file.file
 
                     response = pipeline_api(
                         _file,
                         m_some_parameters=some_parameters,
                         filename=file.filename,
-                        file_content_type=file.content_type,
+                        file_content_type=file_content_type,
                     )
                     if is_multipart:
                         if type(response) not in [str, bytes]:
@@ -144,11 +197,13 @@ async def pipeline_1(
             file = files[0]
             _file = file.file
 
+            file_content_type = get_validated_mimetype(file)
+
             response = pipeline_api(
                 _file,
                 m_some_parameters=some_parameters,
                 filename=file.filename,
-                file_content_type=file.content_type,
+                file_content_type=file_content_type,
             )
 
             return response
@@ -158,11 +213,6 @@ async def pipeline_1(
             content='Request parameter "files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
-
-
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
-    return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 
 app.include_router(router)

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
@@ -141,8 +141,8 @@ def ungz_file(file: UploadFile) -> UploadFile:
     )
 
 
-@router.post("/{ cookiecutter.pipeline_family }}/v0/process-file")
-@router.post("/{ cookiecutter.pipeline_family }}/v0.0.1/process-file")
+@router.post("/{{ cookiecutter.pipeline_family }}/v0/process-file")
+@router.post("/{{ cookiecutter.pipeline_family }}/v0.0.1/process-file")
 def pipeline_1(
     request: Request,
     files: Union[List[UploadFile], None] = File(default=None),

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_text.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_text.py
@@ -156,8 +156,8 @@ def ungz_file(file: UploadFile) -> UploadFile:
     )
 
 
-@router.post("/{ cookiecutter.pipeline_family }}/v0/process-text")
-@router.post("/{ cookiecutter.pipeline_family }}/v0.0.1/process-text")
+@router.post("/{{ cookiecutter.pipeline_family }}/v0/process-text")
+@router.post("/{{ cookiecutter.pipeline_family }}/v0.0.1/process-text")
 def pipeline_1(
     request: Request,
     text_files: Union[List[UploadFile], None] = File(default=None),

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_text.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_text.py
@@ -3,15 +3,25 @@
 # DO NOT MODIFY DIRECTLY
 #####################################################################
 
+import io
 import os
+import gzip
+import mimetypes
 from typing import List, Union
-from fastapi import status, FastAPI, File, Form, Request, UploadFile, APIRouter
-from slowapi.errors import RateLimitExceeded
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
+from fastapi import (
+    status,
+    FastAPI,
+    File,
+    Form,
+    Request,
+    UploadFile,
+    APIRouter,
+    HTTPException,
+)
 from fastapi.responses import PlainTextResponse
 import json
 from fastapi.responses import StreamingResponse
+from starlette.datastructures import Headers
 from starlette.types import Send
 from base64 import b64encode
 from typing import Optional, Mapping, Iterator, Tuple
@@ -21,13 +31,8 @@ from unstructured.staging.base import convert_to_isd, convert_to_isd_csv
 from unstructured.staging.label_studio import stage_for_label_studio
 
 
-limiter = Limiter(key_func=get_remote_address)
 app = FastAPI()
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 router = APIRouter()
-
-RATE_LIMIT = os.environ.get("PIPELINE_API_RATE_LIMIT", "1/second")
 
 
 def is_expected_response_type(media_type, response_type):
@@ -50,6 +55,36 @@ def pipeline_api(text, response_type="application/json", response_schema="isd"):
     elif response_type == "text/csv":
         return convert_to_isd_csv([text])
     return {"message": "unsupported arguments"}
+
+
+def get_validated_mimetype(file):
+    """
+    Return a file's mimetype, either via the file.content_type or the mimetypes lib if that's too
+    generic. If the user has set UNSTRUCTURED_ALLOWED_MIMETYPES, validate against this list and
+    return HTTP 400 for an invalid type.
+    """
+    content_type = file.content_type
+    if not content_type or content_type == "application/octet-stream":
+        content_type = mimetypes.guess_type(str(file.filename))[0]
+
+        # Markdown mimetype is too new for the library - just hardcode that one in for now
+        if not content_type and ".md" in file.filename:
+            content_type = "text/markdown"
+
+    allowed_mimetypes_str = os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES")
+    if allowed_mimetypes_str is not None:
+        allowed_mimetypes = allowed_mimetypes_str.split(",")
+
+        if content_type not in allowed_mimetypes:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unable to process {file.filename}: "
+                    f"File type {content_type} is not supported."
+                ),
+            )
+
+    return content_type
 
 
 class MultipartMixedResponse(StreamingResponse):
@@ -110,14 +145,30 @@ class MultipartMixedResponse(StreamingResponse):
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
-@router.post("/{{ cookiecutter.pipeline_family }}/v0.0.1/process-text")
-@limiter.limit(RATE_LIMIT)
-async def pipeline_1(
+def ungz_file(file: UploadFile) -> UploadFile:
+    filename = str(file.filename) if file.filename else ""
+    gzip_file = gzip.open(file.file)
+    return UploadFile(
+        file=io.BytesIO(gzip_file.read()),
+        size=len(gzip_file.read()),
+        filename=filename[:-3] if len(filename) > 3 else "",
+        headers=Headers({"content-type": str(mimetypes.guess_type(filename)[0])}),
+    )
+
+
+@router.post("/{ cookiecutter.pipeline_family }}/v0/process-text")
+@router.post("/{ cookiecutter.pipeline_family }}/v0.0.1/process-text")
+def pipeline_1(
     request: Request,
     text_files: Union[List[UploadFile], None] = File(default=None),
     output_format: Union[str, None] = Form(default=None),
     output_schema: str = Form(default=None),
 ):
+    if text_files:
+        for file_index in range(len(text_files)):
+            if text_files[file_index].content_type == "application/gzip":
+                text_files[file_index] = ungz_file(text_files[file_index])
+
     content_type = request.headers.get("Accept")
 
     default_response_type = output_format or "application/json"
@@ -145,6 +196,8 @@ async def pipeline_1(
 
             def response_generator(is_multipart):
                 for file in text_files:
+                    get_validated_mimetype(file)
+
                     text = file.file.read().decode("utf-8")
 
                     response = pipeline_api(
@@ -195,11 +248,6 @@ async def pipeline_1(
             content='Request parameter "text_files" is required.\n',
             status_code=status.HTTP_400_BAD_REQUEST,
         )
-
-
-@app.get("/healthcheck", status_code=status.HTTP_200_OK)
-async def healthcheck(request: Request):
-    return {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}
 
 
 app.include_router(router)

--- a/{{ cookiecutter.repo_name }}/scripts/check-and-format-notebooks.py
+++ b/{{ cookiecutter.repo_name }}/scripts/check-and-format-notebooks.py
@@ -17,9 +17,46 @@ from unstructured_api_tools.pipelines.convert import read_notebook
 def process_nb(nb: nbformat.NotebookNode, working_dir: Union[str, Path]) -> nbformat.NotebookNode:
     """Execute cells in nb using working_dir as the working directory for imports, modifying the
     notebook in place (in memory)."""
+    # Clear existing outputs before executing the notebook
+    for cell in nb.cells:
+        if cell.cell_type == "code":
+            cell.outputs = []
     ep = ExecutePreprocessor(timeout=600)
     ep.preprocess(nb, {"metadata": {"path": working_dir}})
+    # Merge adjacent text outputs after executing the notebook
+    for cell in nb.cells:
+        merge_adjacent_text_outputs(cell)
     return nb
+
+
+def merge_adjacent_text_outputs(cell: nbformat.NotebookNode) -> nbformat.NotebookNode:
+    """Merges adjacent text stream outputs to avoid non-deterministic splits in output."""
+    if cell.cell_type != "code":
+        return cell
+
+    new_outputs = []
+    current_output = None
+
+    for output in cell.outputs:
+        if output.output_type == "stream":
+            if current_output is None:
+                current_output = output
+            elif current_output.name == output.name:
+                current_output.text += output.text
+            else:
+                new_outputs.append(current_output)
+                current_output = output
+        else:
+            if current_output is not None:
+                new_outputs.append(current_output)
+                current_output = None
+            new_outputs.append(output)
+
+    if current_output is not None:
+        new_outputs.append(current_output)
+
+    cell.outputs = new_outputs
+    return cell
 
 
 def nb_paths(root_path: Union[str, Path]) -> List[Path]:
@@ -91,6 +128,7 @@ if __name__ == "__main__":
     nonmatching_nbs = []
     fns = notebooks if notebooks else nb_paths(root_path)
     for fn in fns:
+        print(f"{'checking' if check else 'processing'} {fn}")
         nb = read_notebook(fn)
         modified_nb = deepcopy(nb)
         process_nb(modified_nb, root_path)

--- a/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_file.py
+++ b/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_file.py
@@ -55,10 +55,3 @@ def test_pipeline_1(test_client, files, some_parameters, status_code, headers):
         headers=headers if headers else None,
     )
     assert response.status_code == status_code
-
-
-@pytest.mark.skip(reason="/healthcheck does not exist for pipeline notebook api yet")
-def test_healthcheck(test_client):
-    response = test_client.get("/healthcheck")
-    assert response.status_code == 200
-    assert response.json() == {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_file.py
+++ b/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_file.py
@@ -57,6 +57,7 @@ def test_pipeline_1(test_client, files, some_parameters, status_code, headers):
     assert response.status_code == status_code
 
 
+@pytest.mark.skip(reason="/healthcheck does not exist for pipeline notebook api yet")
 def test_healthcheck(test_client):
     response = test_client.get("/healthcheck")
     assert response.status_code == 200

--- a/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_text.py
+++ b/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_text.py
@@ -60,10 +60,3 @@ def test_pipeline_1(test_client, files, output_format, output_schema, status_cod
         "/{{ cookiecutter.pipeline_package }}/v0.0.1/process-text", files=files, headers=headers if headers else None
     )
     assert response.status_code == status_code
-
-
-@pytest.mark.skip(reason="/healthcheck does not exist for pipeline notebook api yet")
-def test_healthcheck(test_client):
-    response = test_client.get("/healthcheck")
-    assert response.status_code == 200
-    assert response.json() == {"healthcheck": "HEALTHCHECK STATUS: EVERYTHING OK!"}

--- a/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_text.py
+++ b/{{ cookiecutter.repo_name }}/test_{{ cookiecutter.pipeline_package }}/api/test_process_text.py
@@ -62,6 +62,7 @@ def test_pipeline_1(test_client, files, output_format, output_schema, status_cod
     assert response.status_code == status_code
 
 
+@pytest.mark.skip(reason="/healthcheck does not exist for pipeline notebook api yet")
 def test_healthcheck(test_client):
     response = test_client.get("/healthcheck")
     assert response.status_code == 200


### PR DESCRIPTION
- print notebooks as they checked/processed by scripts/check-and-format-notebooks.py ,
which makes debuging a touch easier when there is a failure. Also just nice to see what
it is going on if there are no changes -- it takes awhile to process 5 notebooks.
- Merge output stream cells to avoid non-deterministic diff errors like (which are actually equivalent outputs)

Ref: https://github.com/Unstructured-IO/pipeline-sec-filings/pull/117