### PR TITLE
chore: update all bash scripts to use shebang: /usr/bin/env bash

### DIFF
--- a/scripts/docker-validate.sh
+++ b/scripts/docker-validate.sh
@@ -35,7 +35,7 @@ if [[ $(curl -X 'POST' \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -F 'files=@Makefile' \
-     -F 'some_parameter=something' | grep -P '(Makefile:application/octet-stream|Makefile:None)') == "" ]]; then
+     -F 'some_parameter=something' | grep -E '(Makefile:application/octet-stream|Makefile:None)') == "" ]]; then
     echo "Did not get expected output from API"
     kill %1
     exit 1

--- a/{{ cookiecutter.repo_name }}/Dockerfile
+++ b/{{ cookiecutter.repo_name }}/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:experimental
-
-FROM centos:centos7.9.2009
+FROM quay.io/unstructured-io/base-images:rocky8.7-2
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html
@@ -9,32 +8,36 @@ ARG NB_UID=1000
 ARG PIP_VERSION
 ARG PIPELINE_FAMILY
 
-RUN yum -y update && \
-  yum -y install gcc openssl-devel bzip2-devel libffi-devel make git sqlite-devel && \
-  curl -O https://www.python.org/ftp/python/3.8.15/Python-3.8.15.tgz && tar -xzf Python-3.8.15.tgz && \
-  cd Python-3.8.15/ && ./configure --enable-optimizations && make altinstall && \
-  cd .. && rm -rf Python-3.8.15* && \
-  ln -s /usr/local/bin/python3.8 /usr/local/bin/python3
 
-# create user with a home directory
+# Set up environment
 ENV USER ${NB_USER}
 ENV HOME /home/${NB_USER}
 
 RUN groupadd --gid ${NB_UID} ${NB_USER}
-RUN useradd --uid ${NB_UID}  --gid ${NB_UID} ${NB_USER}
-USER ${NB_USER}
+RUN useradd --uid ${NB_UID} --gid ${NB_UID} ${NB_USER}
 WORKDIR ${HOME}
+RUN mkdir ${HOME}/.ssh && chmod go-rwx ${HOME}/.ssh \
+  &&  ssh-keyscan -t rsa github.com >> /home/${NB_USER}/.ssh/known_hosts
+
 ENV PYTHONPATH="${PYTHONPATH}:${HOME}"
 ENV PATH="/home/${NB_USER}/.local/bin:${PATH}"
 
-COPY logger_config.yaml logger_config.yaml
-COPY requirements/dev.txt requirements-dev.txt
 COPY requirements/base.txt requirements-base.txt
+COPY requirements/dev.txt requirements-dev.txt
+RUN python3.8 -m pip install pip==${PIP_VERSION} \
+  && dnf -y groupinstall "Development Tools" \
+  && su -l ${NB_USER} -c 'pip3.8 install  --no-cache  -r requirements-base.txt' \
+  && su -l ${NB_USER} -c 'pip3.8 install  --no-cache  -r requirements-dev.txt' \
+  && dnf -y groupremove "Development Tools" \
+  && dnf clean all \
+  && ln -s /home/notebook-user/.local/bin/pip /usr/local/bin/pip || true
+
+USER ${NB_USER}
+
+COPY logger_config.yaml logger_config.yaml
 COPY prepline_${PIPELINE_FAMILY}/ prepline_${PIPELINE_FAMILY}/
 COPY exploration-notebooks exploration-notebooks
 COPY pipeline-notebooks pipeline-notebooks
 
 
-RUN python3.8 -m pip install pip==${PIP_VERSION} \
-  && pip3.8 install --no-cache -r requirements-base.txt \
-  && pip3.8 install --no-cache -r requirements-dev.txt
+RUN pip3.8 install --no-cache -r requirements-dev.txt

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/app.py
@@ -5,6 +5,8 @@
 
 
 from fastapi import FastAPI, Request, status
+import logging
+import os
 
 from .process_file import router as process_file_router
 from .process_text import router as process_text_router
@@ -18,8 +20,28 @@ app = FastAPI(
     openapi_url="/{{ cookiecutter.pipeline_family }}/openapi.json",
 )
 
+allowed_origins = os.environ.get("ALLOWED_ORIGINS", None)
+if allowed_origins:
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins.split(","),
+        allow_methods=["OPTIONS", "POST"],
+        allow_headers=["Content-Type"],
+    )
+
 app.include_router(process_file_router)
 app.include_router(process_text_router)
+
+
+# Filter out /healthcheck noise
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage().find("/healthcheck") == -1
+
+
+logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 
 @app.get("/healthcheck", status_code=status.HTTP_200_OK, include_in_schema=False)

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_file.py
@@ -43,9 +43,12 @@ def get_validated_mimetype(file):
     if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
-        # Markdown mimetype is too new for the library - just hardcode that one in for now
-        if not content_type and ".md" in file.filename:
-            content_type = "text/markdown"
+        # Some filetypes missing for this library, just hardcode them for now
+        if not content_type:
+            if file.filename.endswith(".md"):
+                content_type = "text/markdown"
+            elif file.filename.endswith(".msg"):
+                content_type = "message/rfc822"
 
     allowed_mimetypes_str = os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES")
     if allowed_mimetypes_str is not None:

--- a/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_text.py
+++ b/{{ cookiecutter.repo_name }}/prepline_{{ cookiecutter.pipeline_package }}/api/process_text.py
@@ -58,9 +58,12 @@ def get_validated_mimetype(file):
     if not content_type or content_type == "application/octet-stream":
         content_type = mimetypes.guess_type(str(file.filename))[0]
 
-        # Markdown mimetype is too new for the library - just hardcode that one in for now
-        if not content_type and ".md" in file.filename:
-            content_type = "text/markdown"
+        # Some filetypes missing for this library, just hardcode them for now
+        if not content_type:
+            if file.filename.endswith(".md"):
+                content_type = "text/markdown"
+            elif file.filename.endswith(".msg"):
+                content_type = "message/rfc822"
 
     allowed_mimetypes_str = os.environ.get("UNSTRUCTURED_ALLOWED_MIMETYPES")
     if allowed_mimetypes_str is not None:

--- a/{{ cookiecutter.repo_name }}/scripts/docker-build.sh
+++ b/{{ cookiecutter.repo_name }}/scripts/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/{{ cookiecutter.repo_name }}/scripts/shellcheck.sh
+++ b/{{ cookiecutter.repo_name }}/scripts/shellcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 find scripts -name "*.sh" -exec shellcheck {} +
 

--- a/{{ cookiecutter.repo_name }}/scripts/version-sync.sh
+++ b/{{ cookiecutter.repo_name }}/scripts/version-sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function usage {
     echo "Usage: $(basename "$0") [-c] -f FILE_TO_CHANGE REPLACEMENT_FORMAT [-f FILE_TO_CHANGE REPLACEMENT_FORMAT ...]" 2>&1
     echo 'Synchronize files to latest version in source file'


### PR DESCRIPTION
Update all bash scripts with #!/bin/bash to use /usr/bin/env bash.

bonus: updates cookie cutter code to parallel changes in unstructured_api_tools
bonus: bumps template Dockerfile to build from unstructured base image (paralleling how this is currently built in unstructured-api)
bonus: use -E instead of -P for the grep (which has wider availability and also supports that particular pattern)
